### PR TITLE
Bioschemas JSON-LD for resources

### DIFF
--- a/components/modal/Ontology.vue
+++ b/components/modal/Ontology.vue
@@ -57,7 +57,7 @@ function reset() {
 function submit() {
   if (currentSelection.value) {
     emit('add-key-value',
-        'https://purl.org/dc/terms/conformsTo',
+        'http://purl.org/dc/terms/conformsTo',
         `{"@type": "CreativeWork", "@id": "${currentSelection.value.iri}", "url": "${createMetadataLink(currentSelection.value.id)}"}`,
         v2KeyValueVariant.KEY_VALUE_VARIANT_STATIC_LABEL)
     reset()

--- a/composables/ResourceInfo.ts
+++ b/composables/ResourceInfo.ts
@@ -1,0 +1,205 @@
+import type {
+  modelsv2License,
+  v2Author,
+  v2Collection,
+  v2Dataset,
+  v2GenericResource,
+  v2KeyValue,
+  v2Object,
+  v2Project,
+  v2Relation,
+  v2Stats
+} from "~/composables/aruna_api_json"
+import {modelsv2Status, v2DataClass, v2PermissionLevel, v2ResourceVariant} from "~/composables/aruna_api_json"
+import type {EndpointInfo} from "~/composables/proto_conversions"
+
+export class ResourceInfo {
+  public id: string
+  public name: string
+  public title: string
+  public variant: v2ResourceVariant
+  public description: string
+  public authors: v2Author[]
+  public keyValues: v2KeyValue[]
+  public stats: v2Stats
+  public dataClass: v2DataClass
+  public createdAt: string
+  public relations: v2Relation[]
+  public objectStatus: modelsv2Status
+  public permission: v2PermissionLevel
+  public metaLicense: modelsv2License
+  public dataLicense: modelsv2License
+  public endpoints: EndpointInfo[]
+
+  constructor(id: string,
+              name: string,
+              title: string,
+              variant: v2ResourceVariant,
+              description: string,
+              authors: v2Author[],
+              keyValues: v2KeyValue[],
+              stats: v2Stats,
+              dataClass: v2DataClass,
+              createdAt: string,
+              relations: v2Relation[],
+              objectStatus: modelsv2Status,
+              permission: v2PermissionLevel,
+              metaLicense: modelsv2License,
+              dataLicense: modelsv2License,
+              endpoints: EndpointInfo[]) {
+    this.id = id;
+    this.name = name;
+    this.title = title;
+    this.variant = variant;
+    this.description = description;
+    this.authors = authors;
+    this.keyValues = keyValues;
+    this.stats = stats;
+    this.dataClass = dataClass;
+    this.createdAt = createdAt;
+    this.relations = relations;
+    this.objectStatus = objectStatus;
+    this.permission = permission;
+    this.metaLicense = metaLicense;
+    this.dataLicense = dataLicense;
+    this.endpoints = endpoints;
+  }
+
+  static fromHierarchicalResource(resource: v2Project | v2Collection | v2Dataset,
+                                  resourceType: v2ResourceVariant): ResourceInfo {
+    return new ResourceInfo(
+        resource.id || '',
+        resource.name || '',
+        resource.title || '',
+        resourceType,
+        resource.description || '',
+        resource.authors || [],
+        resource.keyValues || [],
+        resource.stats || {size: '0', count: '0', lastUpdated: resource.createdAt || ''},
+        resource.dataClass || v2DataClass.DATA_CLASS_UNSPECIFIED,
+        resource.createdAt || '',
+        resource.relations || [],
+        resource.status || modelsv2Status.STATUS_UNSPECIFIED,
+        v2PermissionLevel.PERMISSION_LEVEL_UNSPECIFIED,
+        {tag: resource.metadataLicenseTag, name: '', text: '', url: ''},
+        {tag: resource.defaultDataLicenseTag, name: '', text: '', url: ''},
+        resource.endpoints || []
+    )
+  }
+
+  static fromObject(object: v2Object): ResourceInfo {
+    return new ResourceInfo(
+        object.id || '',
+        object.name || '',
+        object.title || '',
+        v2ResourceVariant.RESOURCE_VARIANT_OBJECT,
+        object.description || '',
+        object.authors || [],
+        object.keyValues || [],
+        {size: object.contentLen, count: '1', lastUpdated: object.createdAt || ''},
+        object.dataClass || v2DataClass.DATA_CLASS_UNSPECIFIED,
+        object.createdAt || '',
+        object.relations || [],
+        object.status || modelsv2Status.STATUS_UNSPECIFIED,
+        v2PermissionLevel.PERMISSION_LEVEL_UNSPECIFIED,
+        {tag: object.metadataLicenseTag, name: '', text: '', url: ''},
+        {tag: object.dataLicenseTag, name: '', text: '', url: ''},
+        object.endpoints || []
+    )
+  }
+
+  static fromParts(resource: v2GenericResource,
+                   permission: v2PermissionLevel,
+                   metaLicense?: modelsv2License,
+                   dataLicense?: modelsv2License): ResourceInfo {
+    let resourceInfo = undefined
+    if (resource.project) {
+      resourceInfo = ResourceInfo.fromHierarchicalResource(resource.project, v2ResourceVariant.RESOURCE_VARIANT_PROJECT)
+    } else if (resource.collection) {
+      resourceInfo = ResourceInfo.fromHierarchicalResource(resource.collection, v2ResourceVariant.RESOURCE_VARIANT_COLLECTION)
+    } else if (resource.dataset) {
+      resourceInfo = ResourceInfo.fromHierarchicalResource(resource.dataset, v2ResourceVariant.RESOURCE_VARIANT_DATASET)
+    } else if (resource.object) {
+      resourceInfo = ResourceInfo.fromObject(resource.object)
+    }
+
+    if (resourceInfo) {
+      resourceInfo.permission = permission
+      resourceInfo.metaLicense = metaLicense ? metaLicense : resourceInfo.metaLicense
+      resourceInfo.dataLicense = dataLicense ? dataLicense : resourceInfo.dataLicense
+      return resourceInfo
+    }
+
+    throw new ArunaError(418, 'Strange.')
+  }
+
+  toJsonLd(): Object {
+    return resourceInfoToJsonLd(this)
+  }
+}
+
+export function resourceInfoToJsonLd(resource: ResourceInfo): Object {
+  const host = useRuntimeConfig().public.websiteHost // window.location.origin ?
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Dataset',
+    '@id': `https://w3id.org/aruna/${resource.id}`,
+    'http://purl.org/dc/terms/conformsTo': {
+      "@type": "CreativeWork",
+      "@id": "https://bioschemas.org/profiles/Dataset/1.0-RELEASE"
+    },
+    identifier: `${host}/objects/${resource.id}`,
+    name: resource.name,
+    alternateName: resource.title,
+    description: resource.description,
+    dateCreated: resource.createdAt,
+    license: {
+      '@type': 'CreativeWork',
+      name: resource.metaLicense.name,
+      url: resource.metaLicense.url,
+      description: 'License under which the dataset metadata can be distributed.'
+    },
+    about: resource.variant === v2ResourceVariant.RESOURCE_VARIANT_OBJECT ? extractAboutFromKeyValues(resource.keyValues, resource.dataLicense) : undefined,
+    url: `${host}/objects/${resource.id}`,
+    creator: authorsToJsonLd(resource.authors)
+  }
+}
+
+export function extractAboutFromKeyValues(keyValues: v2KeyValue[], dataLicense: modelsv2License): Object | undefined {
+  let about = {
+    license: {
+      '@type': 'CreativeWork',
+      name: dataLicense.name,
+      url: dataLicense.url,
+      description: 'License under which the dataset data can be distributed.'
+    },
+    'http://purl.org/dc/terms/conformsTo': undefined,
+  }
+
+  for (const kv of keyValues) {
+    if (kv.key === 'http://purl.org/dc/terms/conformsTo') {
+      about["http://purl.org/dc/terms/conformsTo"] = kv.value ? JSON.parse(kv.value) : undefined
+      break
+    }
+  }
+
+  return about
+}
+
+export function authorsToJsonLd(authors: v2Author[]): Object | undefined {
+  if (authors.length <= 0)
+    return undefined
+
+  let jsonLdAuthors = []
+  for (const author of authors) {
+    jsonLdAuthors.push({
+      '@type': 'Person',
+      identifier: `https://orcid.org/${author.orcid}`,
+      familyName: author.lastName,
+      givenName: author.firstName,
+      email: author.email
+    })
+  }
+
+  return jsonLdAuthors
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -71,6 +71,7 @@ export default defineNuxtConfig({
       dd: ['mt-1', 'ps-4', 'leading-6', 'text-gray-700', 'sm:col-span-2', 'sm:mt-0']
     },
     public: {
+      websiteHost: 'http://localhost:3000',
       infoBanner: {
         active: false,
         title: 'Info banner title: ',

--- a/server/api/license.get.ts
+++ b/server/api/license.get.ts
@@ -1,0 +1,6 @@
+import {fetchCachedLicense} from "~/server/utils/licence";
+
+export default defineEventHandler(async event => {
+  const licenseTag = getQuery(event)['tag']
+  return await fetchCachedLicense(licenseTag as string)
+})

--- a/server/api/object/[id]/json-ld.get.ts
+++ b/server/api/object/[id]/json-ld.get.ts
@@ -1,0 +1,20 @@
+import {ResourceInfo} from "~/composables/ResourceInfo";
+
+interface ResourceInfoResponse extends Response {
+  resource: ResourceInfo
+  jsonLd: Object
+}
+
+export default defineEventHandler(async event => {
+  const resourceId = getRouterParam(event, 'id')
+  const baseUrl = useRuntimeConfig().serverHostUrl
+  const fetchUrl = `${baseUrl}/v2/resources/${resourceId}`
+
+  const {jsonLd} = await $fetch<ResourceInfoResponse>('/api/resource-info', {
+    query: {
+      resourceId: resourceId
+    }
+  })
+
+  return jsonLd ? jsonLd : {}
+})

--- a/server/api/resource-info.ts
+++ b/server/api/resource-info.ts
@@ -1,0 +1,50 @@
+import type {v2GetResourceResponse} from '~/composables/aruna_api_json'
+import {ResourceInfo} from "~/composables/ResourceInfo";
+
+export default defineEventHandler(async event => {
+  const access_token = getCookie(event, 'access_token') // Does not matter if undefined
+  const resourceId = getQuery(event)['resourceId'] as string
+  const noLicenseText = getQuery(event)['noLicenseText'] as boolean
+
+
+  const baseUrl = useRuntimeConfig().serverHostUrl
+  const fetchUrl = `${baseUrl}/v2/resources/${resourceId}`
+
+  return await $fetch<v2GetResourceResponse>(fetchUrl, {
+    headers: access_token ? {
+      'Authorization': `Bearer ${access_token}`
+    } : {}
+  }).then(async response => {
+    const resource = response.resource?.resource
+    const permission = response.resource?.permission
+    let metaLicense = undefined
+    let dataLicense = undefined
+
+    if (resource && permission) {
+      if (resource.project) {
+        metaLicense = await fetchCachedLicense(resource.project.metadataLicenseTag || '')
+        dataLicense = await fetchCachedLicense(resource.project.defaultDataLicenseTag || '')
+      } else if (resource.collection) {
+        metaLicense = await fetchCachedLicense(resource.collection.metadataLicenseTag || '')
+        dataLicense = await fetchCachedLicense(resource.collection.defaultDataLicenseTag || '')
+      } else if (resource.dataset) {
+        metaLicense = await fetchCachedLicense(resource.dataset.metadataLicenseTag || '')
+        dataLicense = await fetchCachedLicense(resource.dataset.defaultDataLicenseTag || '')
+      } else if (resource.object) {
+        metaLicense = await fetchCachedLicense(resource.object.metadataLicenseTag || '')
+        dataLicense = await fetchCachedLicense(resource.object.dataLicenseTag || '')
+      }
+
+      // Create ResourceInfo object
+      const info = ResourceInfo.fromParts(resource, permission, metaLicense, dataLicense)
+
+      // Remove license text to save on response size
+      if (noLicenseText)
+        info.metaLicense.text = info.dataLicense.text = ''
+
+      return {resource: info, jsonLd: info.toJsonLd()}
+    }
+
+    return undefined
+  })
+})

--- a/server/middleware/json-ld.ts
+++ b/server/middleware/json-ld.ts
@@ -1,0 +1,15 @@
+
+export default defineEventHandler(async (event) => {
+  if (event.headers.has('Content-Type') && event.headers.get('Content-Type') === 'application/ld+json') {
+    const PATH_REGEX: RegExp = new RegExp('^/objects/(?<ulid>[0-7][0-9A-HJKMNP-TV-Z]{25})$')
+    const result = PATH_REGEX.exec(event.path)
+    const resourceId = result?.groups ? result?.groups['ulid'] : undefined
+
+    if (resourceId) {
+      setResponseHeaders(event, {
+        'Content-Type': 'application/ld+json'
+      })
+      return await $fetch(`/api/object/${resourceId}/json-ld`)
+    }
+  }
+})

--- a/server/utils/licence.ts
+++ b/server/utils/licence.ts
@@ -1,0 +1,19 @@
+import {modelsv2License, v2GetLicenseResponse} from "~/composables/aruna_api_json";
+
+export const fetchCachedLicense = defineCachedFunction(async (licenseTag: string): Promise<modelsv2License | undefined> => {
+  const baseUrl = useRuntimeConfig().serverHostUrl
+  const fetchUrl = licenseTag ? `${baseUrl}/v2/licenses/${licenseTag}` : `${baseUrl}/v2/licenses`
+
+  return await $fetch<v2GetLicenseResponse>(fetchUrl)
+      .then(response => response.license)
+      .catch(error => {
+        console.error(error)
+        return undefined
+      })
+}, {
+  group: 'licenses',
+  name: 'license-tag',
+  maxAge: useRuntimeConfig().cacheMaxAge || 60 * 60 * 24 * 365, // Defaults to 1 year
+  swr: false,
+  getKey: (licenseTag: string) => licenseTag,
+})


### PR DESCRIPTION
This introduces a Bioschemas-compliant JSON-LD representation to the resource landing pages. By embedding structured metadata that adheres to the Bioschemas specifications, we enhance the discoverability and interoperability of our resources in search engines and other platforms. This addition will allow for better indexing, making our resources more accessible and easier to integrate with external systems. The JSON-LD implementation follows best practices to ensure alignment with Bioschemas guidelines and improve the overall semantic richness of our web pages.

## Changes

* Get license requests are now cached on the server-side
* New server-side API route to fetch complete ResourceInfo object: `/api/resource-info`
* New server-side API route to fetch JSON-LD representation of a specific resource: `/api/object/[id]/json-ld`
* Get requests to landing pages containing the header `Content-Type: application/ld+json` return the JSON-LD representation of the resource
* Landing pages now contain the Bioschemas-compliant JSON-LD representation of the resource in the `<head>` section of the page